### PR TITLE
Fix meta tags and added missing elements in the HTML `<head>`

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,27 +2,44 @@
 <html lang="en">
 
 <head>
+  <!-- Meta tags-->
   <meta charset="UTF-8">
-  <title>SPWN Documentation</title>
-  <meta content="SPWN Documentation" property="og:title">
-  <meta
-    content="Documentation for the SPWN programming language, a language that converts code to Geometry Dash levels."
-    property="og:description">
-  <meta content="https://spu7nix.net/spwn" property="og:url">
-  <meta content="https://spu7nix.net/spwn/assets/spwn_logo_large.png" property="og:image">
-  <meta content="#72cf5f" data-react-helmet="true" name="theme-color">
-
-  <meta property="theme-color" content="#72cf5f">
-
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="content">
   <meta name="viewport"
     content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta property="description" content="SPWN is a programming language that compiles to Geometry Dash levels. This means that you can create levels not only by using the visual representation in the GD-editor, but also by using a
+    verbal and abstracted representation. This is particularly useful for using GD triggers, which are not suited for
+    the graphical workflow of the in-game editor, especially if you want to make complicated stuff." />
+
+  <!--   Themes   -->
+  <meta content="#72cf5f" data-react-helmet="true" name="theme-color">
+  <meta property="theme-color" content="#72cf5f">
+
+  <!-- Open Graph     -->
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://spu7nix.net/spwn" />
+  <meta property="og:title" content="SPWN Documentation" />
+  <meta property="og:description" content="SPWN is a programming language that compiles to Geometry Dash levels. This means that you can create levels not only by using the visual representation in the GD-editor, but also by using a
+    verbal and abstracted representation. This is particularly useful for using GD triggers, which are not suited for
+    the graphical workflow of the in-game editor, especially if you want to make complicated stuff." />
+
+  <meta property="og:image" content="./assets/spwn_logo_smol.png" />
+  <meta property="og:image:width" content="256" />
+  <meta property="og:image:height" content="256" />
+
+  <!-- Title -->
+  <title>SPWN Documentation</title>
+
+  <!-- Page Icon -->
+  <link rel="icon" type="image/png" href="./assets/spwn_logo_smol.png" />
+
+  <!--  Libraries and vendors  -->
   <link rel="stylesheet" href="https://unpkg.com/docsify-themeable@0.8.4/dist/css/theme-simple-dark.css">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/sidebar.min.css" />
 
 
-
+  <!-- CSS -->
   <style>
     /* Custom color theme. */
     :root {

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
     the graphical workflow of the in-game editor, especially if you want to make complicated stuff." />
 
   <meta property="og:image" content="./assets/spwn_logo_smol.png" />
-  <meta property="og:image:width" content="256" />
-  <meta property="og:image:height" content="256" />
+  <meta property="og:image:width" content="128" />
+  <meta property="og:image:height" content="128" />
 
   <!-- Title -->
   <title>SPWN Documentation</title>


### PR DESCRIPTION
## Description:
I made some changes to the HTML header of the SPWN documentation website to improve its SEO and accessibility. 

Specifically, I updated the meta tags to include a proper description, title, and Open Graph tags, and I added missing elements such as the page icon. 
These changes make it easier for search engines to crawl and index the website.

## Changes made:

New and improved HTML `<head>` tag
```html
<head>
  <!-- Meta tags-->
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
  <meta name="viewport"
    content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
  <meta property="description" content="SPWN is a programming language that compiles to Geometry Dash levels. This means that you can create levels not only by using the visual representation in the GD-editor, but also by using a
    verbal and abstracted representation. This is particularly useful for using GD triggers, which are not suited for
    the graphical workflow of the in-game editor, especially if you want to make complicated stuff." />

  <!--   Themes   -->
  <meta content="#72cf5f" data-react-helmet="true" name="theme-color">
  <meta property="theme-color" content="#72cf5f">

  <!-- Open Graph     -->
  <meta property="og:type" content="website" />
  <meta property="og:url" content="https://spu7nix.net/spwn" />
  <meta property="og:title" content="SPWN Documentation" />
  <meta property="og:description" content="SPWN is a programming language that compiles to Geometry Dash levels. This means that you can create levels not only by using the visual representation in the GD-editor, but also by using a
    verbal and abstracted representation. This is particularly useful for using GD triggers, which are not suited for
    the graphical workflow of the in-game editor, especially if you want to make complicated stuff." />

  <meta property="og:image" content="./assets/spwn_logo_smol.png" />
  <meta property="og:image:width" content="256" />
  <meta property="og:image:height" content="256" />

  <!-- Title -->
  <title>SPWN Documentation</title>

  <!-- Page Icon -->
  <link rel="icon" type="image/png" href="./assets/spwn_logo_smol.png" />

  <!--  Libraries and vendors  -->
  <link rel="stylesheet" href="https://unpkg.com/docsify-themeable@0.8.4/dist/css/theme-simple-dark.css">
  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-sidebar-collapse/dist/sidebar.min.css" />


  <!-- CSS -->

  <style>...</style>
</head>
```